### PR TITLE
Fix admin upload state and expose assessment preview links

### DIFF
--- a/pages/AdminUploadPage.tsx
+++ b/pages/AdminUploadPage.tsx
@@ -15,6 +15,10 @@ const BookUploadRow: React.FC<{ book: Book, initialHasPdf: boolean, onUploadComp
   const [uploadState, setUploadState] = useState<UploadState>({ status: 'idle', message: '' });
   const [hasPdf, setHasPdf] = useState(initialHasPdf);
 
+  useEffect(() => {
+    setHasPdf(initialHasPdf);
+  }, [initialHasPdf]);
+
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files[0]) {
       if (e.target.files[0].type === 'application/pdf') {
@@ -56,6 +60,7 @@ const BookUploadRow: React.FC<{ book: Book, initialHasPdf: boolean, onUploadComp
     try {
       await deletePdf(book.id);
       setHasPdf(false); // Update UI to show upload controls
+      onUploadComplete();
     } catch (error) {
       console.error("Failed to delete PDF", error);
       setUploadState({ status: 'error', message: "Could not remove existing PDF." });

--- a/pages/QuestionnairePage.tsx
+++ b/pages/QuestionnairePage.tsx
@@ -254,6 +254,7 @@ const QuestionnairePage: React.FC = () => {
         englishWorkbook: answers.englishSkill ? getBookId('English Workbook') : null,
         mathSkill: answers.mathSkill ? getBookId('Math Skill') : null,
         mathWorkbook: answers.mathSkill ? getBookId('Math Workbook') : null,
+        assessment: answers.assessment ? getBookId('Assessment') : null,
         evs: getBookId('EVS'),
         rhymes: getBookId('Rhymes & Stories'),
         art: getBookId('Art & Craft'),
@@ -325,6 +326,11 @@ const QuestionnairePage: React.FC = () => {
                     <div className="space-y-4">
                         {OPTIONS.assessment.map(type => (<RadioCard key={type.value} id={`assess-${type.value}`} name="assessment" value={type.value} label={type.value} description={type.description} checked={answers.assessment === type.value} onChange={e => setAnswers({ assessment: e.target.value as any })} />))}
                     </div>
+                    {answers.assessment && (
+                        <div className="mt-6 p-3 bg-primary-50 border border-primary-200 rounded-lg flex items-center justify-center">
+                            <BookPreviewLink bookId={bookIds.assessment} label="View Assessment Book" />
+                        </div>
+                    )}
                 </div>);
             case 4: // Core Subjects
                  return (<div>


### PR DESCRIPTION
## Summary
- sync each admin upload row's status with IndexedDB updates
- refresh the stored key list after removing a PDF so the UI reflects the change
- provide an assessment preview link once a format is selected in the questionnaire

## Testing
- ⚠️ `npm install` *(fails: registry returned 403 for @types/node)*

------
https://chatgpt.com/codex/tasks/task_b_68ca8c0af39883258e8883176d794065