### PR TITLE
Add math workbook writing assist option for Nursery and LKG

### DIFF
--- a/data/catalog.ts
+++ b/data/catalog.ts
@@ -34,9 +34,12 @@ export const CATALOG: Book[] = [
   { id: 'NUR-MATH-SKILL-1-10', class_level: 'Nursery', subject: 'Math Skill', language: null, variant: '1–10', price_inr: 250 },
   { id: 'NUR-MATH-SKILL-1-20', class_level: 'Nursery', subject: 'Math Skill', language: null, variant: '1–20', price_inr: 250 },
   { id: 'NUR-MATH-SKILL-1-50', class_level: 'Nursery', subject: 'Math Skill', language: null, variant: '1–50', price_inr: 250 },
-  { id: 'NUR-MATH-WB-1-10', class_level: 'Nursery', subject: 'Math Workbook', language: null, variant: '1–10', price_inr: 200 },
-  { id: 'NUR-MATH-WB-1-20', class_level: 'Nursery', subject: 'Math Workbook', language: null, variant: '1–20', price_inr: 200 },
-  { id: 'NUR-MATH-WB-1-50', class_level: 'Nursery', subject: 'Math Workbook', language: null, variant: '1–50', price_inr: 200 },
+  { id: 'NUR-MATH-WB-1-10-N', class_level: 'Nursery', subject: 'Math Workbook', language: null, variant: '1–10 (Normal)', price_inr: 200 },
+  { id: 'NUR-MATH-WB-1-10-A', class_level: 'Nursery', subject: 'Math Workbook', language: null, variant: '1–10 (Writing Assist)', price_inr: 200 },
+  { id: 'NUR-MATH-WB-1-20-N', class_level: 'Nursery', subject: 'Math Workbook', language: null, variant: '1–20 (Normal)', price_inr: 200 },
+  { id: 'NUR-MATH-WB-1-20-A', class_level: 'Nursery', subject: 'Math Workbook', language: null, variant: '1–20 (Writing Assist)', price_inr: 200 },
+  { id: 'NUR-MATH-WB-1-50-N', class_level: 'Nursery', subject: 'Math Workbook', language: null, variant: '1–50 (Normal)', price_inr: 200 },
+  { id: 'NUR-MATH-WB-1-50-A', class_level: 'Nursery', subject: 'Math Workbook', language: null, variant: '1–50 (Writing Assist)', price_inr: 200 },
   
   // Nursery Core
   { id: 'NUR-EVS', class_level: 'Nursery', subject: 'EVS', language: null, variant: 'Standard', price_inr: 300 },
@@ -59,9 +62,12 @@ export const CATALOG: Book[] = [
   { id: 'LKG-MATH-SKILL-1-100', class_level: 'LKG', subject: 'Math Skill', language: null, variant: '1–100', price_inr: 250 },
   { id: 'LKG-MATH-SKILL-1-100-NAMES', class_level: 'LKG', subject: 'Math Skill', language: null, variant: '1–100 & 1–50 number names', price_inr: 250 },
   { id: 'LKG-MATH-SKILL-1-50-TENS', class_level: 'LKG', subject: 'Math Skill', language: null, variant: '1–50 tens & ones', price_inr: 250 },
-  { id: 'LKG-MATH-WB-1-100', class_level: 'LKG', subject: 'Math Workbook', language: null, variant: '1–100', price_inr: 200 },
-  { id: 'LKG-MATH-WB-1-100-NAMES', class_level: 'LKG', subject: 'Math Workbook', language: null, variant: '1–100 & 1–50 number names', price_inr: 200 },
-  { id: 'LKG-MATH-WB-1-50-TENS', class_level: 'LKG', subject: 'Math Workbook', language: null, variant: '1–50 tens & ones', price_inr: 200 },
+  { id: 'LKG-MATH-WB-1-100-N', class_level: 'LKG', subject: 'Math Workbook', language: null, variant: '1–100 (Normal)', price_inr: 200 },
+  { id: 'LKG-MATH-WB-1-100-A', class_level: 'LKG', subject: 'Math Workbook', language: null, variant: '1–100 (Writing Assist)', price_inr: 200 },
+  { id: 'LKG-MATH-WB-1-100-NAMES-N', class_level: 'LKG', subject: 'Math Workbook', language: null, variant: '1–100 & 1–50 number names (Normal)', price_inr: 200 },
+  { id: 'LKG-MATH-WB-1-100-NAMES-A', class_level: 'LKG', subject: 'Math Workbook', language: null, variant: '1–100 & 1–50 number names (Writing Assist)', price_inr: 200 },
+  { id: 'LKG-MATH-WB-1-50-TENS-N', class_level: 'LKG', subject: 'Math Workbook', language: null, variant: '1–50 tens & ones (Normal)', price_inr: 200 },
+  { id: 'LKG-MATH-WB-1-50-TENS-A', class_level: 'LKG', subject: 'Math Workbook', language: null, variant: '1–50 tens & ones (Writing Assist)', price_inr: 200 },
 
   // LKG Core
   { id: 'LKG-EVS', class_level: 'LKG', subject: 'EVS', language: null, variant: 'Standard', price_inr: 250 },

--- a/types.ts
+++ b/types.ts
@@ -18,6 +18,7 @@ export interface QuestionnaireAnswers {
   englishSkill: string | null;
   englishSkillWritingFocus: 'Caps' | 'Small' | 'Caps & Small' | null;
   englishWorkbookAssist: boolean | null;
+  mathWorkbookAssist: boolean | null;
   mathSkill: string | null;
   assessment: 'Termwise' | 'Annual' | 'Annual (no marks)' | null;
   includeEVS: boolean;


### PR DESCRIPTION
## Summary
- add math workbook assist tracking to questionnaire answers and update math step UI to collect the selection
- compose math workbook preview IDs with the writing assist flag and show the choice in the summaries
- extend the catalog with Normal and Writing Assist math workbook variants for Nursery and LKG

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68ccf494604c832594d522b362bc8886