### PR TITLE
Remove edit action from class summary step

### DIFF
--- a/pages/QuestionnairePage.tsx
+++ b/pages/QuestionnairePage.tsx
@@ -793,14 +793,13 @@ const QuestionnairePage: React.FC = () => {
                                 <p className="text-sm text-gray-600">{item.value}</p>
                                 {item.bookLabel && <div className="mt-1"><BookPreviewLink bookId={item.bookId || null} label={item.bookLabel} /></div>}
                             </div>
-                            <div className="flex gap-2">
-                                <button onClick={() => navigateToStep(currentClassIndex, item.step, { fromSummary: true })} className="text-sm font-semibold text-primary-600 hover:text-primary-800 px-3 py-1 rounded-md hover:bg-primary-100">
-                                    Edit
-                                </button>
-                                {item.canRemove && item.onRemove && (<button onClick={item.onRemove} className="text-sm font-semibold text-red-600 hover:text-red-800 px-3 py-1 rounded-md hover:bg-red-100">
-                                    Remove
-                                </button>)}
-                            </div>
+                            {item.canRemove && item.onRemove && (
+                                <div className="flex gap-2">
+                                    <button onClick={item.onRemove} className="text-sm font-semibold text-red-600 hover:text-red-800 px-3 py-1 rounded-md hover:bg-red-100">
+                                        Remove
+                                    </button>
+                                </div>
+                            )}
                         </div>))}
                     </div>
                     <div className="mt-4">


### PR DESCRIPTION
## Summary
- remove the edit button from the per-class summary step so users can review selections without navigation options

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cd309273988325ba8146ed1d3b6466