### PR TITLE
Add edit controls to class summary items

### DIFF
--- a/pages/QuestionnairePage.tsx
+++ b/pages/QuestionnairePage.tsx
@@ -796,13 +796,16 @@ const QuestionnairePage: React.FC = () => {
                                 <p className="text-sm text-gray-600">{item.value}</p>
                                 {item.bookLabel && <div className="mt-1"><BookPreviewLink bookId={item.bookId || null} label={item.bookLabel} /></div>}
                             </div>
-                            {item.canRemove && item.onRemove && (
-                                <div className="flex gap-2">
+                            <div className="flex gap-2 sm:justify-end">
+                                <button onClick={() => navigateToStep(currentClassIndex, item.step)} className="text-sm font-semibold text-primary-600 hover:text-primary-800 px-3 py-1 rounded-md hover:bg-primary-100">
+                                    Edit
+                                </button>
+                                {item.canRemove && item.onRemove && (
                                     <button onClick={item.onRemove} className="text-sm font-semibold text-red-600 hover:text-red-800 px-3 py-1 rounded-md hover:bg-red-100">
                                         Remove
                                     </button>
-                                </div>
-                            )}
+                                )}
+                            </div>
                         </div>))}
                     </div>
                     <div className="mt-4">


### PR DESCRIPTION
## Summary
- add an Edit action to each class summary row so users can return to the corresponding step
- keep the Remove action conditional but render alongside the new Edit control

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cd396681388325914a75687f6acd52