### PR TITLE
Clamp language selection count to literal union

### DIFF
--- a/pages/QuestionnairePage.tsx
+++ b/pages/QuestionnairePage.tsx
@@ -486,11 +486,12 @@ const QuestionnairePage: React.FC = () => {
                     return { ...current, includeArt: false };
                 case 'language': {
                     const newSelections = current.languages.selections.filter((_, idx) => idx !== action.index);
+                    const newCount = Math.min(2, Math.max(0, newSelections.length)) as 0 | 1 | 2;
                     return {
                         ...current,
                         languages: {
                             ...current.languages,
-                            count: Math.max(0, newSelections.length), // ✅ safer than type cast
+                            count: newCount,
                             selections: newSelections,
                         },
                     };


### PR DESCRIPTION
## Summary
- clamp the language selection count to a 0 | 1 | 2 literal before saving it in questionnaire state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cd3e8ceb7483259594ed206fbf390c