### PR TITLE
Fix TypeScript typing conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/hooks/usePdfStore.tsx
+++ b/hooks/usePdfStore.tsx
@@ -1,13 +1,16 @@
 
+import type { ReactNode } from 'react';
+
 // This hook is deprecated and no longer in use.
 // PDF state management has been moved to a more robust IndexedDB solution
 // located in `services/api.ts` to handle cross-tab state and large files.
 // This file is kept to prevent breaking existing imports but can be safely removed
 // if all references are updated.
 
-const DeprecatedHook = () => {
+const DeprecatedHook = (): never => {
     throw new Error('usePdfStore is deprecated. Use the IndexedDB functions from services/api.ts instead.');
 };
 
 export const usePdfStore = DeprecatedHook;
-export const PdfProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => <>{children}</>;
+
+export const PdfProvider = ({ children }: { children: ReactNode }) => <>{children}</>;

--- a/pages/QuestionnairePage.tsx
+++ b/pages/QuestionnairePage.tsx
@@ -161,7 +161,17 @@ const SummaryList: React.FC<{ entries: SummaryEntry[]; containerClassName?: stri
 );
 
 // --- UI COMPONENTS ---
-const RadioCard = ({ id, name, value, label, description, checked, onChange }: { id: string, name: string, value: string, label: string, description: string, checked: boolean, onChange: (e: React.ChangeEvent<HTMLInputElement>) => void }) => (
+type RadioCardProps = {
+    id: string;
+    name: string;
+    value: string;
+    label: string;
+    description: string;
+    checked: boolean;
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+};
+
+const RadioCard: React.FC<RadioCardProps> = ({ id, name, value, label, description, checked, onChange }) => (
     <label
         className={`relative flex items-start p-4 border rounded-lg cursor-pointer transition-all focus-within:ring-2 focus-within:ring-primary-500 focus-within:border-primary-500 ${checked ? 'bg-primary-50 border-primary-500 ring-2 ring-primary-500' : 'bg-white border-gray-300 hover:border-primary-400'}`}
     >
@@ -183,7 +193,16 @@ const RadioCard = ({ id, name, value, label, description, checked, onChange }: {
     </label>
 );
 
-const CheckboxCard = ({ id, name, label, description, checked, onChange }: { id: string, name: string, label: string, description: string, checked: boolean, onChange: (e: React.ChangeEvent<HTMLInputElement>) => void }) => (
+type CheckboxCardProps = {
+    id: string;
+    name: string;
+    label: string;
+    description: string;
+    checked: boolean;
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+};
+
+const CheckboxCard: React.FC<CheckboxCardProps> = ({ id, name, label, description, checked, onChange }) => (
     <div className={`relative flex items-start p-4 border rounded-lg cursor-pointer transition-all ${checked ? 'bg-primary-50 border-primary-500 ring-2 ring-primary-500' : 'bg-white border-gray-300 hover:border-primary-400'}`}>
         <div className="flex items-center h-5"><input id={id} name={name} type="checkbox" checked={checked} onChange={onChange} className="focus:ring-primary-500 h-4 w-4 text-primary-600 border-gray-300 rounded"/></div>
         <div className="ml-3 text-sm">


### PR DESCRIPTION
## Summary
- ignore build artifacts and node modules to keep the worktree clean
- import React types in the deprecated PDF store shim and annotate the thrown error as never returning
- add explicit prop types for the questionnaire radio and checkbox controls so TypeScript accepts usage with keys

## Testing
- npx tsc --noEmit
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cd442f722083259d52ec9ccbe6e051