### PR TITLE
Fix summary navigation after editing steps

### DIFF
--- a/pages/QuestionnairePage.tsx
+++ b/pages/QuestionnairePage.tsx
@@ -240,11 +240,6 @@ const QuestionnairePage: React.FC = () => {
             return;
         }
 
-        if (step < totalStepsPerClass) {
-            setStep(step + 1);
-            return;
-        }
-
         if (summaryReturnTarget === 'class') {
             setSummaryReturnTarget(null);
             setStep(totalStepsPerClass);
@@ -253,6 +248,11 @@ const QuestionnairePage: React.FC = () => {
 
         if (summaryReturnTarget === 'final') {
             returnToSummary();
+            return;
+        }
+
+        if (step < totalStepsPerClass) {
+            setStep(step + 1);
             return;
         }
 


### PR DESCRIPTION
## Summary
- prioritize summary return handling in handleNext so editing steps jump back to the correct summary
- keep the Nursery language step skip logic intact when advancing through questions

## Testing
- npm run build
- node - <<'NODE' (navigation flow simulation)


------
https://chatgpt.com/codex/tasks/task_b_68d59bb1c0148325824e2b58406a2304