### PR TITLE
Redesign questionnaire language selection flow

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -26,7 +26,6 @@ export interface QuestionnaireAnswers {
   includeArt: boolean;
   languages: {
     count: 0 | 1 | 2;
-    region: 'Karnataka' | 'Tamil Nadu' | 'Other';
     selections: LanguageSelection[];
   };
 }


### PR DESCRIPTION
## Summary
- remove region-based presets from the language configuration and simplify the questionnaire answer shape
- redesign the language step to choose the number of languages first and pick selections from a row-wise list with variant buttons
- update the per-class summary and progress indicators to reflect the new language data structure

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d59f18a9148325b4039517770cd749