### PR TITLE
Hide language progress indicator for Nursery header

### DIFF
--- a/pages/QuestionnairePage.tsx
+++ b/pages/QuestionnairePage.tsx
@@ -950,11 +950,15 @@ const QuestionnairePage: React.FC = () => {
                 </div>
                 <div className="mt-3 text-sm font-semibold text-primary-700">
                     <span>Base selected: {progress.base}/8</span>
-                    <span className="mx-2">•</span>
-                    <span>
-                        Languages: {progress.languagesSelected}
-                        {progress.languagesDesired > 0 ? `/${progress.languagesDesired}` : ''}
-                    </span>
+                    {currentClass !== 'Nursery' && (
+                        <>
+                            <span className="mx-2">•</span>
+                            <span>
+                                Languages: {progress.languagesSelected}
+                                {progress.languagesDesired > 0 ? `/${progress.languagesDesired}` : ''}
+                            </span>
+                        </>
+                    )}
                 </div>
             </>}
         </div>


### PR DESCRIPTION
## Summary
- hide the header languages counter when configuring Nursery to avoid showing unused progress
- preserve the bullet and progress display for other class levels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d620938e248325a1d64adcca231001