### PR TITLE
Handle workbook opt-outs separately

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -18,8 +18,10 @@ export interface QuestionnaireAnswers {
   englishSkill: string | null;
   englishSkillWritingFocus: 'Caps' | 'Small' | 'Caps & Small' | null;
   englishWorkbookAssist: boolean | null;
+  includeEnglishWorkbook: boolean;
   mathWorkbookAssist: boolean | null;
   mathSkill: string | null;
+  includeMathWorkbook: boolean;
   assessment: 'Termwise' | 'Annual' | 'Annual (no marks)' | null;
   includeEVS: boolean;
   includeRhymes: boolean;


### PR DESCRIPTION
## Summary
- add include flags to questionnaire answers so English and Math workbooks default in and reset when skills change
- update removal actions and summaries to treat workbook opt-outs independently of skill choices and clear assists
- hide workbook previews and assist pickers when excluded while keeping skill summaries and book ids intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d63809e2b483258a82caeff815cc23