### PR TITLE
Adjust progress counts for optional workbooks

### DIFF
--- a/pages/QuestionnairePage.tsx
+++ b/pages/QuestionnairePage.tsx
@@ -434,8 +434,18 @@ const QuestionnairePage: React.FC = () => {
 
     const progress = useMemo(() => {
         let coreBooksSelected = 0;
-        if (isEnglishSelectionComplete(answers)) coreBooksSelected += 2;
-        if (isMathSelectionComplete(answers)) coreBooksSelected += 2;
+        if (isEnglishSelectionComplete(answers)) {
+            coreBooksSelected += 1;
+            if (answers.includeEnglishWorkbook) {
+                coreBooksSelected += 1;
+            }
+        }
+        if (isMathSelectionComplete(answers)) {
+            coreBooksSelected += 1;
+            if (answers.includeMathWorkbook) {
+                coreBooksSelected += 1;
+            }
+        }
         if (answers.assessment) coreBooksSelected++;
         if (answers.includeEVS) coreBooksSelected++;
         if (answers.includeRhymes) coreBooksSelected++;


### PR DESCRIPTION
## Summary
- update progress calculations to only count English and Math workbooks when they remain selected
- ensure core book totals reflect the workbook toggles without altering other summary logic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d654c14960832586a21079ae68edc8