### PR TITLE
Enable back navigation on Nursery questionnaire step

### DIFF
--- a/pages/QuestionnairePage.tsx
+++ b/pages/QuestionnairePage.tsx
@@ -1526,7 +1526,7 @@ const QuestionnairePage: React.FC = () => {
         </div>
 
         <div className="mt-8 flex justify-between items-center">
-          <button onClick={handleBack} disabled={showClassIntro || (currentClassIndex === 0 && step === 1 && !showFinalSummary)} className="bg-gray-300 text-gray-800 px-6 py-2 rounded-md hover:bg-gray-400 disabled:bg-gray-200 disabled:cursor-not-allowed">
+          <button onClick={handleBack} disabled={showClassIntro} className="bg-gray-300 text-gray-800 px-6 py-2 rounded-md hover:bg-gray-400 disabled:bg-gray-200 disabled:cursor-not-allowed">
             Back
           </button>
           <div className="flex gap-3">


### PR DESCRIPTION
## Summary
- ensure the questionnaire back button remains active while viewing the Nursery steps
- allow users to return to the class selection screen from Nursery step 1

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d771466e808325b13021fdeb44e0b1