### PR TITLE
Sync upload row PDF status with prop updates

### DIFF
--- a/pages/AdminUploadPage.tsx
+++ b/pages/AdminUploadPage.tsx
@@ -15,6 +15,10 @@ const BookUploadRow: React.FC<{ book: Book, initialHasPdf: boolean, onUploadComp
   const [uploadState, setUploadState] = useState<UploadState>({ status: 'idle', message: '' });
   const [hasPdf, setHasPdf] = useState(initialHasPdf);
 
+  useEffect(() => {
+    setHasPdf(initialHasPdf);
+  }, [initialHasPdf]);
+
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files[0]) {
       if (e.target.files[0].type === 'application/pdf') {


### PR DESCRIPTION
## Summary
- ensure BookUploadRow updates its hasPdf state when the initialHasPdf prop changes so UI reflects refreshed PDF data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d781c632c0832585a4b57ec15dc005