### PR TITLE
Make live summary sidebar read-only

### DIFF
--- a/pages/QuestionnairePage.tsx
+++ b/pages/QuestionnairePage.tsx
@@ -1507,7 +1507,7 @@ const QuestionnairePage: React.FC = () => {
                 <div className="lg:sticky lg:top-6 bg-white p-6 rounded-lg border shadow-md">
                     <div>
                         <h2 className="text-lg font-semibold text-gray-800">Current Selections</h2>
-                        <p className="text-sm text-gray-600 mt-1">Review your picks and make quick edits.</p>
+                        <p className="text-sm text-gray-600 mt-1">A quick overview of what’s been chosen so far.</p>
                     </div>
                     <div className="mt-4 space-y-2">
                         {liveSummaryItems.length > 0 ? (
@@ -1526,22 +1526,6 @@ const QuestionnairePage: React.FC = () => {
                                                             theme={summaryTheme}
                                                         />
                                                     </div>
-                                                )}
-                                            </div>
-                                            <div className="flex flex-wrap gap-2 justify-start">
-                                                <button
-                                                    onClick={() => navigateToStep(currentClassIndex, item.step, { fromSummary: 'class' })}
-                                                    className={`text-sm font-semibold ${summaryTheme.text600} ${summaryTheme.hoverText800} px-3 py-1 rounded-md ${summaryTheme.hoverBg100}`}
-                                                >
-                                                    Edit
-                                                </button>
-                                                {item.canRemove && item.onRemove && (
-                                                    <button
-                                                        onClick={item.onRemove}
-                                                        className="text-sm font-semibold text-red-600 hover:text-red-800 px-3 py-1 rounded-md hover:bg-red-100"
-                                                    >
-                                                        Remove
-                                                    </button>
                                                 )}
                                             </div>
                                         </div>


### PR DESCRIPTION
## Summary
- update the live summary panel copy to describe the read-only selections overview
- remove the inline edit/remove controls from the live class summary list while keeping the final summary step unchanged

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d7b0c06574832581b8d7b9a55f6800