### PR TITLE
Hide live summary on class summary step

### DIFF
--- a/pages/QuestionnairePage.tsx
+++ b/pages/QuestionnairePage.tsx
@@ -1497,7 +1497,7 @@ const QuestionnairePage: React.FC = () => {
     );
 
     const renderLiveSummary = () => {
-        if (showClassIntro || showFinalSummary) {
+        if (showClassIntro || showFinalSummary || step === totalStepsPerClass) {
             return null;
         }
 


### PR DESCRIPTION
## Summary
- ensure the live summary sidebar hides when displaying the per-class summary screen

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d7bc2d72fc8325b95ef9c847e9309e