### PR TITLE
Auto-generate workbooks for selected skill variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/types.ts
+++ b/types.ts
@@ -17,9 +17,7 @@ export interface QuestionnaireAnswers {
   classLevel: 'Nursery' | 'LKG' | 'UKG' | null;
   englishSkill: string | null;
   englishSkillWritingFocus: 'Caps' | 'Small' | 'Caps & Small' | null;
-  englishWorkbookAssist: boolean | null;
   includeEnglishWorkbook: boolean;
-  mathWorkbookAssist: boolean | null;
   mathSkill: string | null;
   includeMathWorkbook: boolean;
   assessment: 'Termwise' | 'Annual' | 'Annual (no marks)' | null;


### PR DESCRIPTION
## Summary
- automatically map skill selections to matching workbook variants without separate assist choices
- show the generated workbook variants in step cards, previews, and summaries
- ignore build output and dependencies in version control

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e8e21ef0b8832599c973b4d8e842cf